### PR TITLE
feat: 1차 논의 내용 업데이트

### DIFF
--- a/lib/pages/cart_page/cart_page.dart
+++ b/lib/pages/cart_page/cart_page.dart
@@ -2,6 +2,8 @@ import 'package:dark_horse_book_store/common_widgets/click_button.dart';
 import 'package:flutter/material.dart';
 import 'package:dark_horse_book_store/common_widgets/appbar.dart';
 import 'package:dark_horse_book_store/model/cart_manager.dart';
+import 'package:intl/intl.dart';
+import 'package:dark_horse_book_store/pages/product_list_page/product_list_page.dart';
 import 'widgets/cart_item_tile.dart';
 
 class CartPage extends StatefulWidget {
@@ -19,6 +21,8 @@ class _CartPageState extends State<CartPage> {
   int getTotalPrice() {
     return CartManager.getTotalPrice();
   }
+
+  final NumberFormat formatter = NumberFormat('#,###');
 
   @override
   Widget build(BuildContext context) {
@@ -144,7 +148,7 @@ class _CartPageState extends State<CartPage> {
                         ),
                         // 실제 총 금액 텍스트
                         Text(
-                          "${getTotalPrice().toString()}원",
+                          "₩ ${formatter.format(getTotalPrice())} 원",
                           style: const TextStyle(
                             fontSize: 18,
                             fontWeight: FontWeight.bold,
@@ -162,9 +166,9 @@ class _CartPageState extends State<CartPage> {
                     // ElevatedButton: 입체감이 있는 버튼
                     child: ClickButton(
                       text: "구매하기",
-                      onPressed: () {
+                      onPressed: () async {
                         // 다이얼로그를 표시하는 메서드
-                        showDialog(
+                        final result = await showDialog(
                           context: context,
                           // AlertDialog: 확인/취소 버튼이 있는 팝업 창
                           builder:
@@ -191,9 +195,9 @@ class _CartPageState extends State<CartPage> {
                                 actions: [
                                   // TextButton: 텍스트만 있는 버튼
                                   TextButton(
-                                    onPressed:
-                                        () =>
-                                            Navigator.pop(context), // 다이얼로그 닫기
+                                    onPressed: () {
+                                      Navigator.of(context).pop(true);
+                                    },
                                     child: Text(
                                       "확인",
                                       style: TextStyle(
@@ -205,6 +209,13 @@ class _CartPageState extends State<CartPage> {
                                 ],
                               ),
                         );
+                        if (result == true) {
+                          // 상품목록 페이지로 이동
+                          Navigator.of(context).pushAndRemoveUntil(
+                            MaterialPageRoute(builder: (context) => ProductListPage()),
+                            (route) => false,
+                          );
+                        }
                       },
                     ),
                   ),

--- a/lib/pages/cart_page/widgets/cart_item_tile.dart
+++ b/lib/pages/cart_page/widgets/cart_item_tile.dart
@@ -1,19 +1,23 @@
 import 'package:flutter/material.dart';
+import 'dart:io';
+import 'package:intl/intl.dart';
 
 // 장바구니 아이템 하나를 표시하는 위젯
 class CartItemTile extends StatelessWidget {
-  final Map<String, dynamic> item; // 아이템 정보 (제목, 가격, 수량)
+  final Map<String, dynamic> item; // 아이템 정보 (제목, 가격, 수량, 이미지)
   final VoidCallback onAdd; // 수량 증가 버튼을 눌렀을 때 실행될 함수
   final VoidCallback onRemove; // 수량 감소 버튼을 눌렀을 때 실행될 함수
   final VoidCallback onDelete; // 삭제 버튼을 눌렀을 때 실행될 함수
 
-  const CartItemTile({
+  CartItemTile({
     super.key,
     required this.item,
     required this.onAdd,
     required this.onRemove,
     required this.onDelete,
   });
+
+  final NumberFormat formatter = NumberFormat('#,###');
 
   @override
   Widget build(BuildContext context) {
@@ -25,6 +29,23 @@ class CartItemTile extends StatelessWidget {
         padding: const EdgeInsets.all(16.0),
         child: Row(
           children: [
+            // 상품 이미지 (상품목록과 동일한 사이즈)
+            Container(
+              width: 90,
+              height: 120,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(8),
+                color: Colors.brown[100],
+                border: Border.all(color: Colors.brown[200]!),
+              ),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(10),
+                child: item['image'] is File
+                    ? Image.file(item['image'], fit: BoxFit.cover)
+                    : SizedBox.shrink(),
+              ),
+            ),
+            SizedBox(width: 12),
             // 책 제목과 가격을 표시하는 부분
             Expanded(
               child: Column(
@@ -40,7 +61,7 @@ class CartItemTile extends StatelessWidget {
                   ),
                   const SizedBox(height: 4),
                   Text(
-                    "${item['price'].toString()}원",
+                    "₩ ${formatter.format(item['price'])} 원",
                     style: TextStyle(
                       fontSize: 14,
                       color: Colors.brown.withOpacity(0.7),

--- a/lib/pages/product_detail_page/product_detail_page.dart
+++ b/lib/pages/product_detail_page/product_detail_page.dart
@@ -4,6 +4,7 @@ import 'package:dark_horse_book_store/model/cart_manager.dart';
 import 'package:dark_horse_book_store/common_widgets/appbar.dart';
 import 'package:dark_horse_book_store/common_widgets/click_button.dart';
 import 'package:dark_horse_book_store/pages/cart_page/cart_page.dart';
+import 'package:dark_horse_book_store/pages/product_list_page/product_list_page.dart';
 import 'package:intl/intl.dart';
 
 // 상품 상세 페이지
@@ -132,7 +133,7 @@ class _ProductDetailPageState extends State<ProductDetailPage> {
     );
     // 확인을 누른 경우: 구매 완료 다이얼로그
     if (result == true) {
-      await showDialog(
+      final purchaseResult = await showDialog(
         context: context,
         builder: (context) {
           return AlertDialog(
@@ -140,13 +141,20 @@ class _ProductDetailPageState extends State<ProductDetailPage> {
             content: Text('구매가 완료되었습니다!'),
             actions: [
               TextButton(
-                onPressed: () => Navigator.of(context).pop(), // 확인
+                onPressed: () => Navigator.of(context).pop(true), // 확인
                 child: Text('확인'),
               ),
             ],
           );
         },
       );
+      if (purchaseResult == true) {
+        // 상품목록 페이지로 이동 (스택 모두 제거)
+        Navigator.of(context).pushAndRemoveUntil(
+          MaterialPageRoute(builder: (context) => ProductListPage()),
+          (route) => false,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
- 상세페이지 구매하기 선택하면 상품 목록으로 이동 수정
- 장바구니. 상품 목록 페이지 양식 통일을 위해 이미지 추가
- 장바구니 금액 천단위 적용
- 장바구니에서 구매하면 상품 목록 이동 수정


추가 작업 필요사항> 
구매하고, 상품 목록에 돌아오면 목록 사라지는 현상 수정 필요
장바구니 버튼 구현 중
